### PR TITLE
Handle units

### DIFF
--- a/astrofaker/astrofaker.py
+++ b/astrofaker/astrofaker.py
@@ -9,6 +9,7 @@ from astrodata import wcs as adwcs
 import numpy as np
 from scipy.ndimage.filters import gaussian_filter
 import datetime
+import astropy.units as u
 from astropy.modeling import models
 from astropy.wcs import WCS
 from astropy.io.fits import Header, PrimaryHDU
@@ -343,6 +344,7 @@ class AstroFaker(with_metaclass(abc.ABCMeta, object)):
         shape_value = '['+','.join(['1:{}'] * len(shape))+']'.format(*shape[::-1])
         self[-1].hdr.update({'EXTNAME': 'SCI',
                              'EXTVER': extver,
+                             'BUNIT': 'adu',
                              self._keyword_for('data_section'): shape_value,
                              self._keyword_for('detector_section'): shape_value,
                              self._keyword_for('array_section'): shape_value})
@@ -472,6 +474,11 @@ class AstroFaker(with_metaclass(abc.ABCMeta, object)):
         if shape is None:
             shape = self.data.shape
         self.reset(data=np.zeros(shape), mask=None, variance=None)
+
+    def add(self, other):
+        unit = (u.adu if self.hdr.get('BUNIT', 'ADU').upper() == 'ADU'
+                else u.electron)
+        super().add(other << unit)
 
     @sliceable
     def add_poisson_noise(self, scale=1.0):

--- a/astrofaker/astrofaker.py
+++ b/astrofaker/astrofaker.py
@@ -476,9 +476,11 @@ class AstroFaker(with_metaclass(abc.ABCMeta, object)):
         self.reset(data=np.zeros(shape), mask=None, variance=None)
 
     def add(self, other):
-        unit = (u.adu if self.hdr.get('BUNIT', 'ADU').upper() == 'ADU'
-                else u.electron)
-        super().add(other << unit)
+        if self.nddata.unit is not None:
+            # Use the same unit as self if it is set
+            super().add(other << self.nddata.unit)
+        else:
+            super().add(other)
 
     @sliceable
     def add_poisson_noise(self, scale=1.0):


### PR DESCRIPTION
Overloading `.add` to set the same unit as `self.nddata`, this should be compatible with the current DRAGONS master, and should work for `add_*_noise`, `add_stars` etc. Unless you see a better way ?